### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/dockerCI.yml
+++ b/.github/workflows/dockerCI.yml
@@ -45,7 +45,7 @@ jobs:
         # Strip git ref prefix from version
         VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
 
-        # Only tag and push when a new tag is created
+        # Label image based on repo tag
         if [[ "${{ github.ref }}" == "refs/tags/"* ]]
         then
           # Strip "v" prefix from tag name
@@ -53,10 +53,12 @@ jobs:
   
           docker tag image $IMAGE_ID:$VERSION
           docker tag image $IMAGE_ID:stable
+          docker tag image $IMAGE_ID:latest
   
-          docker push $IMAGE_ID
-
-          echo "Image pushed"
         else
-          echo "Image only pushed on tags"
+          docker tag image $IMAGE_ID:beta
         fi
+
+        docker push $IMAGE_ID
+
+        echo "Image pushed"

--- a/.github/workflows/dockerCI.yml
+++ b/.github/workflows/dockerCI.yml
@@ -53,7 +53,6 @@ jobs:
   
           docker tag image $IMAGE_ID:$VERSION
           docker tag image $IMAGE_ID:stable
-          docker tag image $IMAGE_ID:latest
   
         else
           docker tag image $IMAGE_ID:beta


### PR DESCRIPTION
- updated github action so that ci-cd publishes a "beta" tagged image on any code changes to master that are not a version tag
- version tag still publishes the version number and stable
- removed latest tag per discussions that we aren't going to use

closes #31 
