### PR TITLE
Use IETF status values

### DIFF
--- a/src/app/Controllers/HealthzController.cs
+++ b/src/app/Controllers/HealthzController.cs
@@ -1,4 +1,5 @@
 ﻿using Helium.DataAccessLayer;
+using Helium.Model;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
@@ -47,7 +48,7 @@ namespace Helium.Controllers
 
             HttpContext.Items.Add(typeof(HealthCheckResult).ToString(), res);
 
-            return new ObjectResult(res.Status.ToString())
+            return new ObjectResult(IetfCheck.ToIetfStatus(res.Status))
             {
                 StatusCode = res.Status == HealthStatus.Unhealthy ? (int)System.Net.HttpStatusCode.ServiceUnavailable : (int)System.Net.HttpStatusCode.OK
             };

--- a/src/app/Middleware/requestLogger.cs
+++ b/src/app/Middleware/requestLogger.cs
@@ -175,7 +175,7 @@ namespace Helium
                     string log = string.Empty;
 
                     // build the log message
-                    log += string.Format(CultureInfo.InvariantCulture, $"{hcr.Status}\t{duration,6:0}\t{context.Request.Headers[_ipHeader]}\t{GetPathAndQuerystring(context.Request)}\n");
+                    log += string.Format(CultureInfo.InvariantCulture, $"{IetfCheck.ToIetfStatus(hcr.Status)}\t{duration,6:0}\t{context.Request.Headers[_ipHeader]}\t{GetPathAndQuerystring(context.Request)}\n");
 
 
                     // add each not healthy check to the log message
@@ -183,7 +183,7 @@ namespace Helium
                     {
                         if (d is HealthzCheck h && h.Status != HealthStatus.Healthy)
                         {
-                            log += string.Format(CultureInfo.InvariantCulture, $"{h.Status}\t{(long)h.Duration.TotalMilliseconds,6}\t{context.Request.Headers[_ipHeader]}\t{h.Endpoint}\t({h.TargetDuration.TotalMilliseconds,1:0})\n");
+                            log += string.Format(CultureInfo.InvariantCulture, $"{IetfCheck.ToIetfStatus(h.Status)}\t{(long)h.Duration.TotalMilliseconds,6}\t{context.Request.Headers[_ipHeader]}\t{h.Endpoint}\t({h.TargetDuration.TotalMilliseconds,1:0})\n");
                         }
                     }
 


### PR DESCRIPTION
Converted /healthz and logging to use IETF status codes (up, warn, down) instead of dotnet codes (Healthy, Degraded, Unhealthy)

References retaildevcrews/helium#111