### PR TITLE
Updated to use Semantic Versioning

### DIFF
--- a/src/app/Constants.cs
+++ b/src/app/Constants.cs
@@ -5,7 +5,7 @@
     /// </summary>
     public sealed class Constants
     {
-        public static readonly string SwaggerVersion = "v " + Version.AssemblyVersion;
+        public static readonly string SwaggerVersion = "1.0.0";
         public const string SwaggerName = "helium";
         public const string SwaggerTitle = "Helium";
         public const string SwaggerPath = "/swagger.json";

--- a/src/app/Version.cs
+++ b/src/app/Version.cs
@@ -21,7 +21,7 @@ namespace Helium
 
                     var aVer = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;
 
-                    _version = string.Format(CultureInfo.InvariantCulture, $"{aVer.Major}.{aVer.Minor}.{dt.ToString("MMdd.HHmm", CultureInfo.InvariantCulture)}");
+                    _version = string.Format(CultureInfo.InvariantCulture, $"{aVer.Major}.{aVer.Minor}.{aVer.Build}+{dt.ToString("MMdd.HHmm", CultureInfo.InvariantCulture)}");
                 }
 
                 return _version;

--- a/src/app/helium.csproj
+++ b/src/app/helium.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Helium</RootNamespace>
     <AssemblyName>helium</AssemblyName>
-    <AssemblyVersion>1.0.1.0</AssemblyVersion>
-    <FileVersion>1.0.1.0</FileVersion>
+    <AssemblyVersion>1.0.6.0</AssemblyVersion>
+    <FileVersion>1.0.6.0</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <LangVersion>8.0</LangVersion>

--- a/src/app/helium.csproj
+++ b/src/app/helium.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Helium</RootNamespace>
     <AssemblyName>helium</AssemblyName>
-    <AssemblyVersion>1.6.0.0</AssemblyVersion>
-    <FileVersion>1.6.0.0</FileVersion>
+    <AssemblyVersion>1.0.1.0</AssemblyVersion>
+    <FileVersion>1.0.1.0</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <LangVersion>8.0</LangVersion>

--- a/src/app/wwwroot/swagger.json
+++ b/src/app/wwwroot/swagger.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "Helium",
-    "version": "1.0.0"
+    "version": "1.0"
   },
   "paths": {
     "/api/movies": {

--- a/src/app/wwwroot/swagger.json
+++ b/src/app/wwwroot/swagger.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "Helium",
-    "version": "1.6.0.0"
+    "version": "1.0.0"
   },
   "paths": {
     "/api/movies": {


### PR DESCRIPTION
## Not ready to merge
- Pending final decision

- FB is using major.minor for their API - https://developers.facebook.com/docs/apps/versions
- Twitter as well - https://developer.twitter.com/en/docs/ads/general/overview/versions
- Google is using major only and calls out the delta with SemVer - https://cloud.google.com/apis/design/versioning
- Office 365 uses major.minor (and used a beta version) - https://docs.microsoft.com/en-us/previous-versions/office/office-365-api/
- OpenAPI uses major.minor.patch but their URL is major only - https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md
- APIM
  - https://docs.microsoft.com/en-us/azure/api-management/api-management-get-started-publish-versions
  - https://docs.microsoft.com/en-us/azure/api-management/api-management-get-started-revise-api

- Azure is a hot mess - https://docs.microsoft.com/en-us/azure/search/search-api-versions

## SemVer
- https://semver.org/
- 1.0.6+0310.1231 complies
  - ex: from page - 1.0.0+20130313144700
- SemVer does not discuss versioning APIs separate from assemblies

## Type of PR

- [X] Documentation changes
- [X] Code changes
- [X] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
- Updated to use SemVer
  - API (swagger) is 1.0.0
  - assembly is 1.0.6.0
  - /version returns 1.0.6-MMdd.hhmm

- References retaildevcrews/helium#280
