### PR TITLE
Sql injection param protection

### DIFF
--- a/src/app/DataAccessLayer/dalActors.cs
+++ b/src/app/DataAccessLayer/dalActors.cs
@@ -13,7 +13,7 @@ namespace Helium.DataAccessLayer
     {
         // select template for Actors
         const string _actorSelect = "select m.id, m.partitionKey, m.actorId, m.type, m.name, m.birthYear, m.deathYear, m.profession, m.textSearch, m.movies from m where m.type = 'Actor' ";
-        const string _actorOrderBy = " order by m.textSearch ASC"; //, m.actorId ASC";
+        const string _actorOrderBy = " order by m.textSearch ASC, m.actorId ASC";
         const string _actorOffset = " offset {0} limit {1}";
 
         /// <summary>

--- a/src/app/DataAccessLayer/dalActors.cs
+++ b/src/app/DataAccessLayer/dalActors.cs
@@ -36,36 +36,6 @@ namespace Helium.DataAccessLayer
             return await _cosmosDetails.Container.ReadItemAsync<Actor>(actorId, new PartitionKey(GetPartitionKey(actorId))).ConfigureAwait(false);
         }
 
-        ///// <summary>
-        ///// Parameterize Actors to avoid sql injection attacks
-        ///// </summary>
-        ///// <param name="q">search term</param>
-        ///// <param name="parameters">parameter check</param>
-        ///// <returns>parameterized results</returns>
-        //public async Task<IEnumerable<Actor>> GetMyEntriesAsync(string q, Dictionary<string, object> parameters)
-        //{
-        //    if ((parameters?.Count ?? 0) < 1)
-        //    {
-        //        throw new ArgumentException("Parameters required to prevent SQL injection attacks");
-        //    }
-
-        //    var queryDef = new QueryDefinition(q);
-        //    foreach (var p in parameters)
-        //    {
-        //        queryDef.WithParameter(p.Key, p.Value);
-        //    }
-
-        //    var query = this._cosmosDetails.Container.GetItemQueryIterator<Actor>(queryDef);
-        //    List<Actor> results = new List<Actor>();
-        //    while (query.HasMoreResults)
-        //    {
-        //        var response = await query.ReadNextAsync().ConfigureAwait(false);
-        //        results.AddRange(response.ToList());
-        //    }
-
-        //    return results;
-        //}
-
         /// <summary>
         /// Get a list of Actors by search string
         /// 
@@ -79,9 +49,6 @@ namespace Helium.DataAccessLayer
         public async Task<IEnumerable<Actor>> GetActorsAsync(string q, int offset = 0, int limit = Constants.DefaultPageSize)
         {
             string sql = _actorSelect;
-            string orderby = _actorOrderBy;
-
-            Dictionary<string, string> queryParams = new Dictionary<string, string>();
 
             if (limit < 1)
             {
@@ -94,9 +61,6 @@ namespace Helium.DataAccessLayer
 
             // string offsetLimit = string.Format(CultureInfo.InvariantCulture, _actorOffset, offset, limit);
 
-            queryParams.Add("@offset", offset.ToString());
-            queryParams.Add("@limit", limit.ToString());
-
             if (!string.IsNullOrEmpty(q))
             {
                 // convert to lower and escape embedded '
@@ -107,22 +71,21 @@ namespace Helium.DataAccessLayer
                     // get actors by a "like" search on name
                     //sql += string.Format(CultureInfo.InvariantCulture, $" and contains(m.textSearch, '{q}') ");
                     sql += " and contains(m.textSearch, @q) ";
-                    queryParams.Add("@q", q);
                 }
             }
 
-            sql += orderby + _actorOffset;
+            sql += _actorOrderBy + _actorOffset;
 
-            QueryDefinition queryDef = new QueryDefinition(sql);
-            if(queryParams.Count > 0)
-            {
-                foreach(string param in queryParams.Keys)
-                {
-                    queryDef.WithParameter(param, queryParams[param]);
-                }
-            }
+            QueryDefinition queryDefinition = new QueryDefinition(sql);
 
-            return await InternalCosmosDBSqlQuery<Actor>(queryDef).ConfigureAwait(false);
+            queryDefinition.WithParameter("@offset", offset.ToString());
+            queryDefinition.WithParameter("@limit", limit.ToString());
+
+            if(!string.IsNullOrEmpty(q)) 
+                queryDefinition.WithParameter("@q", q);
+            
+
+            return await InternalCosmosDBSqlQuery<Actor>(queryDefinition).ConfigureAwait(false);
         }
 
     }

--- a/src/app/DataAccessLayer/dalActors.cs
+++ b/src/app/DataAccessLayer/dalActors.cs
@@ -1,6 +1,7 @@
 using Helium.Model;
 using Microsoft.Azure.Cosmos;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Threading.Tasks;
 
 namespace Helium.DataAccessLayer
@@ -12,8 +13,8 @@ namespace Helium.DataAccessLayer
     {
         // select template for Actors
         const string _actorSelect = "select m.id, m.partitionKey, m.actorId, m.type, m.name, m.birthYear, m.deathYear, m.profession, m.textSearch, m.movies from m where m.type = 'Actor' ";
-        const string _actorOrderBy = " order by m.textSearch ASC, m.actorId ASC";
-        const string _actorOffset = " @offset offset @limit limit";
+        const string _actorOrderBy = " order by m.textSearch ASC "; //, m.actorId ASC";
+        const string _actorOffset = " offset {0} limit {1}";
 
         /// <summary>
         /// Retrieve a single Actor from CosmosDB by actorId
@@ -47,6 +48,8 @@ namespace Helium.DataAccessLayer
         {
             string sql = _actorSelect;
 
+
+
             if (limit < 1)
             {
                 limit = Constants.DefaultPageSize;
@@ -56,12 +59,14 @@ namespace Helium.DataAccessLayer
                 limit = Constants.MaxPageSize;
             }
 
-            // string offsetLimit = string.Format(CultureInfo.InvariantCulture, _actorOffset, offset, limit);
+            string offsetLimit = string.Format(CultureInfo.InvariantCulture, _actorOffset, offset, limit);
 
             if (!string.IsNullOrEmpty(q))
             {
                 // convert to lower and escape embedded '
                 q = q.Trim().ToLowerInvariant().Replace("'", "''", System.StringComparison.OrdinalIgnoreCase);
+
+
 
                 if (!string.IsNullOrEmpty(q))
                 {
@@ -71,12 +76,9 @@ namespace Helium.DataAccessLayer
                 }
             }
 
-            sql += _actorOrderBy + _actorOffset;
+            sql += _actorOrderBy + offsetLimit;
 
             QueryDefinition queryDefinition = new QueryDefinition(sql);
-
-            queryDefinition.WithParameter("@offset", offset.ToString());
-            queryDefinition.WithParameter("@limit", limit.ToString());
 
             if (!string.IsNullOrEmpty(q))
             {
@@ -87,5 +89,4 @@ namespace Helium.DataAccessLayer
         }
 
     }
-
 }

--- a/src/app/DataAccessLayer/dalActors.cs
+++ b/src/app/DataAccessLayer/dalActors.cs
@@ -69,8 +69,8 @@ namespace Helium.DataAccessLayer
                 if (!string.IsNullOrEmpty(q))
                 {
                     // get actors by a "like" search on name
-                    //sql += string.Format(CultureInfo.InvariantCulture, $" and contains(m.textSearch, '{q}') ");
-                    sql += " and contains(m.textSearch, @q) ";
+                    sql += string.Format(CultureInfo.InvariantCulture, $" and contains(m.textSearch, @q) ");
+
                 }
             }
 

--- a/src/app/DataAccessLayer/dalActors.cs
+++ b/src/app/DataAccessLayer/dalActors.cs
@@ -12,9 +12,9 @@ namespace Helium.DataAccessLayer
     public partial class DAL
     {
         // select template for Actors
-        const string _actorSelect = "select m.id, m.partitionKey, m.actorId, m.type, m.name, m.birthYear, m.deathYear, m.profession, m.textSearch, m.movies from m where m.type = 'Actor' ";
-        const string _actorOrderBy = " order by m.textSearch ASC, m.actorId ASC";
-        const string _actorOffset = " offset {0} limit {1}";
+        const string actorSelect = "select m.id, m.partitionKey, m.actorId, m.type, m.name, m.birthYear, m.deathYear, m.profession, m.textSearch, m.movies from m where m.type = 'Actor' ";
+        const string actorOrderBy = " order by m.textSearch ASC, m.actorId ASC";
+        const string actorOffset = " offset {0} limit {1}";
 
         /// <summary>
         /// Retrieve a single Actor from CosmosDB by actorId
@@ -47,7 +47,7 @@ namespace Helium.DataAccessLayer
         public async Task<IEnumerable<Actor>> GetActorsAsync(string q, int offset = 0, int limit = Constants.DefaultPageSize)
         {
 
-            string sql = _actorSelect;
+            string sql = actorSelect;
 
 
             if (limit < 1)
@@ -59,7 +59,7 @@ namespace Helium.DataAccessLayer
                 limit = Constants.MaxPageSize;
             }
 
-            string offsetLimit = string.Format(CultureInfo.InvariantCulture, _actorOffset, offset, limit);
+            string offsetLimit = string.Format(CultureInfo.InvariantCulture, actorOffset, offset, limit);
 
             if (!string.IsNullOrEmpty(q))
             {
@@ -74,7 +74,7 @@ namespace Helium.DataAccessLayer
                 }
             }
 
-            sql += _actorOrderBy + offsetLimit;
+            sql += actorOrderBy + offsetLimit;
 
             QueryDefinition queryDefinition = new QueryDefinition(sql);
 

--- a/src/app/DataAccessLayer/dalActors.cs
+++ b/src/app/DataAccessLayer/dalActors.cs
@@ -1,9 +1,6 @@
 using Helium.Model;
 using Microsoft.Azure.Cosmos;
-using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Helium.DataAccessLayer
@@ -16,7 +13,7 @@ namespace Helium.DataAccessLayer
         // select template for Actors
         const string _actorSelect = "select m.id, m.partitionKey, m.actorId, m.type, m.name, m.birthYear, m.deathYear, m.profession, m.textSearch, m.movies from m where m.type = 'Actor' ";
         const string _actorOrderBy = " order by m.textSearch ASC, m.actorId ASC";
-        const string _actorOffset = " offset @offset limit @limit";
+        const string _actorOffset = " @offset offset @limit limit";
 
         /// <summary>
         /// Retrieve a single Actor from CosmosDB by actorId
@@ -81,9 +78,10 @@ namespace Helium.DataAccessLayer
             queryDefinition.WithParameter("@offset", offset.ToString());
             queryDefinition.WithParameter("@limit", limit.ToString());
 
-            if(!string.IsNullOrEmpty(q)) 
+            if (!string.IsNullOrEmpty(q))
+            {
                 queryDefinition.WithParameter("@q", q);
-            
+            }
 
             return await InternalCosmosDBSqlQuery<Actor>(queryDefinition).ConfigureAwait(false);
         }

--- a/src/app/DataAccessLayer/dalActors.cs
+++ b/src/app/DataAccessLayer/dalActors.cs
@@ -13,7 +13,7 @@ namespace Helium.DataAccessLayer
     {
         // select template for Actors
         const string _actorSelect = "select m.id, m.partitionKey, m.actorId, m.type, m.name, m.birthYear, m.deathYear, m.profession, m.textSearch, m.movies from m where m.type = 'Actor' ";
-        const string _actorOrderBy = " order by m.textSearch ASC "; //, m.actorId ASC";
+        const string _actorOrderBy = " order by m.textSearch ASC"; //, m.actorId ASC";
         const string _actorOffset = " offset {0} limit {1}";
 
         /// <summary>
@@ -48,8 +48,6 @@ namespace Helium.DataAccessLayer
         {
             string sql = _actorSelect;
 
-
-
             if (limit < 1)
             {
                 limit = Constants.DefaultPageSize;
@@ -65,8 +63,6 @@ namespace Helium.DataAccessLayer
             {
                 // convert to lower and escape embedded '
                 q = q.Trim().ToLowerInvariant().Replace("'", "''", System.StringComparison.OrdinalIgnoreCase);
-
-
 
                 if (!string.IsNullOrEmpty(q))
                 {

--- a/src/app/DataAccessLayer/dalActors.cs
+++ b/src/app/DataAccessLayer/dalActors.cs
@@ -12,9 +12,9 @@ namespace Helium.DataAccessLayer
     public partial class DAL
     {
         // select template for Actors
-        const string actorSelect = "select m.id, m.partitionKey, m.actorId, m.type, m.name, m.birthYear, m.deathYear, m.profession, m.textSearch, m.movies from m where m.type = 'Actor' ";
-        const string actorOrderBy = " order by m.textSearch ASC, m.actorId ASC";
-        const string actorOffset = " offset {0} limit {1}";
+        const string _actorSelect = "select m.id, m.partitionKey, m.actorId, m.type, m.name, m.birthYear, m.deathYear, m.profession, m.textSearch, m.movies from m where m.type = 'Actor' ";
+        const string _actorOrderBy = " order by m.textSearch ASC, m.actorId ASC";
+        const string _actorOffset = " offset {0} limit {1}";
 
         /// <summary>
         /// Retrieve a single Actor from CosmosDB by actorId
@@ -59,7 +59,7 @@ namespace Helium.DataAccessLayer
                 limit = Constants.MaxPageSize;
             }
 
-            string offsetLimit = string.Format(CultureInfo.InvariantCulture, actorOffset, offset, limit);
+            string offsetLimit = string.Format(CultureInfo.InvariantCulture, _actorOffset, offset, limit);
 
             if (!string.IsNullOrEmpty(q))
             {

--- a/src/app/DataAccessLayer/dalMain.cs
+++ b/src/app/DataAccessLayer/dalMain.cs
@@ -155,7 +155,6 @@ namespace Helium.DataAccessLayer
         /// </summary>
         /// <typeparam name="T">POCO type to which results are serialized and returned.</typeparam>
         /// <param name="queryDefinition">Query to be executed.</param>
-        /// /// <param name="sql">Query to be executed.</param>
         /// <returns>Enumerable list of objects of type T.</returns>
         private async Task<IEnumerable<T>> InternalCosmosDBSqlQuery<T>(QueryDefinition queryDefinition)
         {
@@ -172,7 +171,8 @@ namespace Helium.DataAccessLayer
                         results.Add(doc);
                     }
                 }
-            } catch(Exception ex)
+            }
+            catch (Exception ex)
             {
                 Debug.WriteLine(ex.Message);
             }

--- a/src/app/DataAccessLayer/dalMain.cs
+++ b/src/app/DataAccessLayer/dalMain.cs
@@ -173,7 +173,7 @@ namespace Helium.DataAccessLayer
             return results;
         }
 
-        //TODO: Will remove original sql query once all callers are converted
+        // TODO: Will remove original sql query once all callers are converted
         /// <summary>
         /// Generic function to be used by subclasses to execute arbitrary queries and return type T.
         /// </summary>

--- a/src/app/DataAccessLayer/dalMain.cs
+++ b/src/app/DataAccessLayer/dalMain.cs
@@ -158,7 +158,7 @@ namespace Helium.DataAccessLayer
         private async Task<IEnumerable<T>> InternalCosmosDBSqlQuery<T>(string sql)
         {
             // run query
-            var query = _cosmosDetails.Container.GetItemQueryIterator<T>(sql, requestOptions: _cosmosDetails.QueryRequestOptions);
+            var query = _cosmosDetails.Container.GetItemQueryIterator<T>(sql,requestOptions: _cosmosDetails.QueryRequestOptions);
 
             List<T> results = new List<T>();
 

--- a/src/app/DataAccessLayer/dalMain.cs
+++ b/src/app/DataAccessLayer/dalMain.cs
@@ -158,7 +158,7 @@ namespace Helium.DataAccessLayer
         private async Task<IEnumerable<T>> InternalCosmosDBSqlQuery<T>(QueryDefinition queryDefinition)
         {
             // run query
-            var query = _cosmosDetails.Container.GetItemQueryIterator<T>(queryDefinition, requestOptions: _cosmosDetails.QueryRequestOptions);
+            var query = cosmosDetails.Container.GetItemQueryIterator<T>(queryDefinition, requestOptions: cosmosDetails.QueryRequestOptions);
 
             List<T> results = new List<T>();
 
@@ -173,7 +173,6 @@ namespace Helium.DataAccessLayer
             return results;
         }
 
-        // TODO: Will remove original sql query once all callers are converted
         /// <summary>
         /// Generic function to be used by subclasses to execute arbitrary queries and return type T.
         /// </summary>

--- a/src/app/DataAccessLayer/dalMain.cs
+++ b/src/app/DataAccessLayer/dalMain.cs
@@ -1,7 +1,6 @@
 using Microsoft.Azure.Cosmos;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.Threading.Tasks;
 
@@ -162,20 +161,15 @@ namespace Helium.DataAccessLayer
             var query = _cosmosDetails.Container.GetItemQueryIterator<T>(queryDefinition, requestOptions: _cosmosDetails.QueryRequestOptions);
 
             List<T> results = new List<T>();
-            try
+
+            while (query.HasMoreResults)
             {
-                while (query.HasMoreResults)
+                foreach (var doc in await query.ReadNextAsync().ConfigureAwait(false))
                 {
-                    foreach (var doc in await query.ReadNextAsync().ConfigureAwait(false))
-                    {
-                        results.Add(doc);
-                    }
+                    results.Add(doc);
                 }
             }
-            catch (Exception ex)
-            {
-                Debug.WriteLine(ex.Message);
-            }
+
             return results;
         }
 

--- a/src/app/DataAccessLayer/dalMain.cs
+++ b/src/app/DataAccessLayer/dalMain.cs
@@ -35,7 +35,8 @@ namespace Helium.DataAccessLayer
             cosmosDetails = new CosmosConfig
             {
                 MaxRows = MaxPageSize,
-                Retries = CosmosMaxRetries,
+
+
                 Timeout = CosmosTimeout,
                 CosmosCollection = cosmosCollection,
                 CosmosDatabase = cosmosDatabase,

--- a/src/app/DataAccessLayer/dalMovies.cs
+++ b/src/app/DataAccessLayer/dalMovies.cs
@@ -13,9 +13,9 @@ namespace Helium.DataAccessLayer
     public partial class DAL
     {
         // select template for Movies
-        const string _movieSelect = "select m.id, m.partitionKey, m.movieId, m.type, m.textSearch, m.title, m.year, m.runtime, m.rating, m.votes, m.totalScore, m.genres, m.roles from m where m.type = 'Movie' ";
-        const string _movieOrderBy = " order by m.textSearch ASC, m.movieId ASC";
-        const string _movieOffset = " offset {0} limit {1}";
+        const string movieSelect = "select m.id, m.partitionKey, m.movieId, m.type, m.textSearch, m.title, m.year, m.runtime, m.rating, m.votes, m.totalScore, m.genres, m.roles from m where m.type = 'Movie' ";
+        const string movieOrderBy = " order by m.textSearch ASC, m.movieId ASC";
+        const string movieOffset = " offset {0} limit {1}";
 
         /// <summary>
         /// Retrieve a single Movie from CosmosDB by movieId
@@ -49,7 +49,7 @@ namespace Helium.DataAccessLayer
         public async Task<IEnumerable<Movie>> GetMoviesAsync(string q, string genre = "", int year = 0, double rating = 0, string actorId = "", int offset = 0, int limit = Constants.DefaultPageSize)
         {
 
-            string sql = _movieSelect;
+            string sql = movieSelect;
 
             if (limit < 1)
             {
@@ -60,7 +60,7 @@ namespace Helium.DataAccessLayer
                 limit = Constants.MaxPageSize;
             }
 
-            string offsetLimit = string.Format(CultureInfo.InvariantCulture, _movieOffset, offset, limit);
+            string offsetLimit = string.Format(CultureInfo.InvariantCulture, movieOffset, offset, limit);
 
             if (!string.IsNullOrEmpty(q))
             {
@@ -113,7 +113,7 @@ namespace Helium.DataAccessLayer
                 sql += " and array_contains(m.genres, @genre) ";
             }
 
-            sql += _movieOrderBy + offsetLimit;
+            sql += movieOrderBy + offsetLimit;
 
             // Parameterize fields
             QueryDefinition queryDefinition = new QueryDefinition(sql);

--- a/src/app/DataAccessLayer/dalMovies.cs
+++ b/src/app/DataAccessLayer/dalMovies.cs
@@ -49,8 +49,7 @@ namespace Helium.DataAccessLayer
         public async Task<IEnumerable<Movie>> GetMoviesAsync(string q, string genre = "", int year = 0, double rating = 0, string actorId = "", int offset = 0, int limit = Constants.DefaultPageSize)
         {
             string sql = _movieSelect;
-            // string orderby = _movieOrderBy;
-
+            
             if (limit < 1)
             {
                 limit = Constants.DefaultPageSize;
@@ -70,20 +69,17 @@ namespace Helium.DataAccessLayer
                 if (!string.IsNullOrEmpty(q))
                 {
                     // get movies by a "like" search on title
-                    // sql += string.Format(CultureInfo.InvariantCulture, $" and contains(m.textSearch, '{q}') ");
                     sql += " and contains(m.textSearch, @q) ";
                 }
             }
 
             if (year > 0)
             {
-                // sql += string.Format(CultureInfo.InvariantCulture, $" and m.year = {year} ");
                 sql += " and m.year = @year ";
             }
 
             if (rating > 0)
             {
-                //  sql += string.Format(CultureInfo.InvariantCulture, $" and m.rating >= {rating} ");
                 sql += " and m.rating >= @rating ";
             }
 
@@ -94,12 +90,9 @@ namespace Helium.DataAccessLayer
 
                 if (!string.IsNullOrEmpty(actorId))
                 {
-                    // get movies for an actor
-                    //sql += " and array_contains(m.roles, { actorId: '";
-                    //sql += actorId;
-                    //sql += "' }, true) ";
                     sql += " and array_contains(m.roles, { actorId: @actorId }, true) ";
                 }
+
             }
 
             if (!string.IsNullOrEmpty(genre))
@@ -116,13 +109,12 @@ namespace Helium.DataAccessLayer
                 }
 
                 // get movies by genre
-                //sql += string.Format(CultureInfo.InvariantCulture, $" and array_contains(m.genres, '{genre}') ");
                 sql += " and array_contains(m.genres, @genre) ";
             }
 
-            // sql += orderby + offsetLimit;
             sql += _movieOrderBy + offsetLimit;
 
+            // Parameterize fields
             QueryDefinition queryDefinition = new QueryDefinition(sql);
 
             if (!string.IsNullOrEmpty(q))

--- a/src/app/DataAccessLayer/dalMovies.cs
+++ b/src/app/DataAccessLayer/dalMovies.cs
@@ -49,7 +49,7 @@ namespace Helium.DataAccessLayer
         public async Task<IEnumerable<Movie>> GetMoviesAsync(string q, string genre = "", int year = 0, double rating = 0, string actorId = "", int offset = 0, int limit = Constants.DefaultPageSize)
         {
             string sql = _movieSelect;
-            
+
             if (limit < 1)
             {
                 limit = Constants.DefaultPageSize;

--- a/src/app/DataAccessLayer/dalMovies.cs
+++ b/src/app/DataAccessLayer/dalMovies.cs
@@ -98,7 +98,7 @@ namespace Helium.DataAccessLayer
                     //sql += " and array_contains(m.roles, { actorId: '";
                     //sql += actorId;
                     //sql += "' }, true) ";
-                    sql += " and array_contains(m.roles, { actorId: '@actorId' }, true) ";
+                    sql += " and array_contains(m.roles, { actorId: @actorId }, true) ";
                 }
             }
 

--- a/src/app/DataAccessLayer/dalMovies.cs
+++ b/src/app/DataAccessLayer/dalMovies.cs
@@ -86,8 +86,6 @@ namespace Helium.DataAccessLayer
 
             if (!string.IsNullOrEmpty(actorId))
             {
-
-
                 // convert to lower and escape embedded '
                 actorId = actorId.Trim().ToLowerInvariant().Replace("'", "''", System.StringComparison.OrdinalIgnoreCase);
 

--- a/src/app/DataAccessLayer/dalMovies.cs
+++ b/src/app/DataAccessLayer/dalMovies.cs
@@ -13,9 +13,9 @@ namespace Helium.DataAccessLayer
     public partial class DAL
     {
         // select template for Movies
-        const string movieSelect = "select m.id, m.partitionKey, m.movieId, m.type, m.textSearch, m.title, m.year, m.runtime, m.rating, m.votes, m.totalScore, m.genres, m.roles from m where m.type = 'Movie' ";
-        const string movieOrderBy = " order by m.textSearch ASC, m.movieId ASC";
-        const string movieOffset = " offset {0} limit {1}";
+        const string _movieSelect = "select m.id, m.partitionKey, m.movieId, m.type, m.textSearch, m.title, m.year, m.runtime, m.rating, m.votes, m.totalScore, m.genres, m.roles from m where m.type = 'Movie' ";
+        const string _movieOrderBy = " order by m.textSearch ASC, m.movieId ASC";
+        const string _movieOffset = " offset {0} limit {1}";
 
         /// <summary>
         /// Retrieve a single Movie from CosmosDB by movieId
@@ -50,11 +50,6 @@ namespace Helium.DataAccessLayer
         {
 
             string sql = _movieSelect;
-<<<<<<< HEAD
-=======
-            
-
->>>>>>> 4b7b33c9ed8f428835e51d04eed8cc9e01476ca3
 
             if (limit < 1)
             {
@@ -65,7 +60,7 @@ namespace Helium.DataAccessLayer
                 limit = Constants.MaxPageSize;
             }
 
-            string offsetLimit = string.Format(CultureInfo.InvariantCulture, movieOffset, offset, limit);
+            string offsetLimit = string.Format(CultureInfo.InvariantCulture, _movieOffset, offset, limit);
 
             if (!string.IsNullOrEmpty(q))
             {

--- a/src/app/DataAccessLayer/dalMovies.cs
+++ b/src/app/DataAccessLayer/dalMovies.cs
@@ -86,6 +86,8 @@ namespace Helium.DataAccessLayer
 
             if (!string.IsNullOrEmpty(actorId))
             {
+
+
                 // convert to lower and escape embedded '
                 actorId = actorId.Trim().ToLowerInvariant().Replace("'", "''", System.StringComparison.OrdinalIgnoreCase);
 

--- a/src/app/DataAccessLayer/dalMovies.cs
+++ b/src/app/DataAccessLayer/dalMovies.cs
@@ -78,13 +78,13 @@ namespace Helium.DataAccessLayer
             if (year > 0)
             {
                 // sql += string.Format(CultureInfo.InvariantCulture, $" and m.year = {year} ");
-                sql += " and m.year = '{@year}' ";
+                sql += " and m.year = @year ";
             }
 
             if (rating > 0)
             {
                 //  sql += string.Format(CultureInfo.InvariantCulture, $" and m.rating >= {rating} ");
-                sql += " and m.rating >= '{@rating}' ";
+                sql += " and m.rating >= @rating ";
             }
 
             if (!string.IsNullOrEmpty(actorId))
@@ -117,7 +117,7 @@ namespace Helium.DataAccessLayer
 
                 // get movies by genre
                 //sql += string.Format(CultureInfo.InvariantCulture, $" and array_contains(m.genres, '{genre}') ");
-                sql += " and array_contains(m.genres, '{@genre}') ";
+                sql += " and array_contains(m.genres, @genre) ";
             }
 
             // sql += orderby + offsetLimit;

--- a/src/app/GlobalSuppressions.cs
+++ b/src/app/GlobalSuppressions.cs
@@ -20,3 +20,4 @@
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("IDE", "IDE0051:Private member GetXmlCommentsPath is unused", Justification = "can be used if configured", Scope = "type", Target = "Helium.Startup")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1054:Uri parameters should not be strings", Justification = "KeyVault SDK expects string", Scope = "type", Target = "Helium.App")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "<Pending>", Scope = "member", Target = "~M:Helium.DataAccessLayer.DAL.GetActorsAsync(System.String,System.Int32,System.Int32)~System.Threading.Tasks.Task{System.Collections.Generic.IEnumerable{Helium.Model.Actor}}")]

--- a/src/app/GlobalSuppressions.cs
+++ b/src/app/GlobalSuppressions.cs
@@ -20,4 +20,3 @@
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("IDE", "IDE0051:Private member GetXmlCommentsPath is unused", Justification = "can be used if configured", Scope = "type", Target = "Helium.Startup")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1054:Uri parameters should not be strings", Justification = "KeyVault SDK expects string", Scope = "type", Target = "Helium.App")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "<Pending>", Scope = "member", Target = "~M:Helium.DataAccessLayer.DAL.GetActorsAsync(System.String,System.Int32,System.Int32)~System.Threading.Tasks.Task{System.Collections.Generic.IEnumerable{Helium.Model.Actor}}")]

--- a/src/app/helium.csproj
+++ b/src/app/helium.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.6.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.8.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -26,10 +26,10 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.1" />
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.5" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUi" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.3.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.3.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUi" Version="5.3.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20158.1" />
   </ItemGroup>
 


### PR DESCRIPTION
## Type of PR
PR to switch to CosmosDB native support for parameterized queries to prevent SQL injection attacks.
- [ ] Documentation changes
- [X] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Parameterize queries to protect against SQL injection attacks.
## Review notes

## Issues Closed or Referenced

- Closes #76

