### PR TITLE
Updated scheduled link check to create project cards

### DIFF
--- a/.github/workflows/scheduled_mdlinkcheck.yml
+++ b/.github/workflows/scheduled_mdlinkcheck.yml
@@ -1,4 +1,4 @@
-name: Check Markdown Links
+name: Scheduled Check for Dead Markdown Links
 
 on: 
   schedule:
@@ -23,12 +23,14 @@ jobs:
       with:
         title: Remove dead links from repository
         content-filepath: ./.github/ISSUE_TEMPLATE/found-dead-links.md
+        labels: Documentation
 
     - name: Create Project Card
       if: ${{ failure() }}
       uses: peter-evans/create-or-update-project-card@v1
       with:
+        token: ${{ secrets.BOT_PAT }}
+        project-location: 'retaildevcrews'
         project-number: '1'
         column-name: 'Triage'
         issue-number: ${{ steps.ciff.outputs.issue-number }}
-    

--- a/.github/workflows/scheduled_mdlinkcheck.yml
+++ b/.github/workflows/scheduled_mdlinkcheck.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         title: Remove dead links from repository
         content-filepath: ./.github/ISSUE_TEMPLATE/found-dead-links.md
-        labels: Documentation
+        labels: Documentation, Bug
 
     - name: Create Project Card
       if: ${{ failure() }}


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [x] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Updated scheduled link check workflow to automatically a create project card on Helium project board when dead links are found in markdown files during scheduled automated checks. Previously, auto-generated issues needed to be manually assigned to the project for the project card to be created on the kanban board. Needed to add personal access token stored as org-level secret to implement this.

## Validation

- [ ] Unit tests updated and ran successfully
- [x] Update documentation or issue referenced above

## Issues Closed or Referenced

- References #retaildevcrews/helium/issues/592
