### PR TITLE
Update deprecated set-env commands for actions to new syntax

### DIFF
--- a/.github/workflows/codespaces.yml
+++ b/.github/workflows/codespaces.yml
@@ -29,7 +29,7 @@ jobs:
         # check that all Docker secrets are set
         if [[ "${{ secrets.DOCKER_PAT }}" != "" && "${{ secrets.DOCKER_USER }}" != "" ]];
         then
-          echo "::set-env name=DOCKER_SET::true"
+          echo "DOCKER_SET=true" >> $GITHUB_ENV
         fi
 
     - name: Docker Login

--- a/.github/workflows/dockerCI.yaml
+++ b/.github/workflows/dockerCI.yaml
@@ -53,19 +53,19 @@ jobs:
         # check that all Azure secrets are set
         if [[ "${{ secrets.SERVICE_PRINCIPAL_SECRET }}" != "" && "${{ secrets.TENANT }}" != "" && "${{ secrets.SERVICE_PRINCIPAL }}" != "" && "${{ secrets.KEYVAULT_NAME }}" != "" ]];
         then
-          echo "::set-env name=AZURE_SET::true"
+          echo "AZURE_SET=true" >> $GITHUB_ENV
         fi
 
         # check that all Docker secrets are set
         if [[ "${{ secrets.DOCKER_PAT }}" != "" && "${{ secrets.DOCKER_REPO }}" != "" && "${{ secrets.DOCKER_USER }}" != "" ]];
         then
-          echo "::set-env name=DOCKER_SET::true"
+          echo "DOCKER_SET=true" >> $GITHUB_ENV
         fi
-        
+
         # check that all ACR secrets are set
         if [[ "${{ secrets.ACR_REG }}" != "" && "${{ secrets.ACR_REPO }}" != "" && "${{ secrets.ACR_IMAGE }}" != "" ]];
         then
-          echo "::set-env name=ACR_SET::true"
+          echo "ACR_SET=true" >> $GITHUB_ENV
         fi
 
     - name: PR Closed
@@ -74,7 +74,7 @@ jobs:
       run: |
 
         # handle PR Closed event by building / pushing main branch
-        
+
         # checkout parent branch (usually "main")
         git config pull.ff only
         git fetch --all
@@ -87,11 +87,11 @@ jobs:
       run: |
 
         # Do not build on PR Merged
-        
+
         # Skip remaining steps
-        echo "::set-env name=AZURE_SET::false"
-        echo "::set-env name=DOCKER_SET::false"
-        echo "::set-env name=ACR_SET::false"
+        echo "AZURE_SET=false" >> $GITHUB_ENV
+        echo "DOCKER_SET=false" >> $GITHUB_ENV
+        echo "ACR_SET=false" >> $GITHUB_ENV
 
     - name: Validate Azure Access
       if: ${{ env.AZURE_SET == 'true' }}
@@ -131,7 +131,7 @@ jobs:
       run: |
         # run the app
         docker run -d --name hcs -p 4120:4120 --env KEYVAULT_NAME=$KEYVAULT_NAME --env AUTH_TYPE=CLI -v ~/.azure:/root/.azure test
-        
+
         echo "Waiting for web server to start and run initial tests ..."
         sleep 25
 
@@ -175,7 +175,7 @@ jobs:
         else
           docker build . -t helium
         fi
-        
+
     - name: Docker Tag and Push
       if: ${{ env.DOCKER_SET == 'true' }}
       run: |
@@ -196,7 +196,7 @@ jobs:
 
         # Push to the repo
         docker push $DOCKER_REPO
-    
+
     - name: ACR Push
       if: ${{ env.ACR_SET == 'true' && env.AZURE_SET == 'true' }}
       run: |
@@ -215,14 +215,14 @@ jobs:
 
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-        
+
           # Strip "v" prefix from tag name
           VERSION=$(echo $VERSION | sed -e 's/^v//')
-          
+
           # tag the image with :version and :stable
           docker tag helium $ACR_IMAGE:$VERSION
           docker tag helium $ACR_IMAGE:stable
         fi
-        
+
         # push the repo
         docker push $ACR_IMAGE

--- a/.github/workflows/experimentalCI.txt
+++ b/.github/workflows/experimentalCI.txt
@@ -50,19 +50,19 @@ jobs:
         # check that all Azure secrets are set
         if [[ "${{ secrets.SERVICE_PRINCIPAL_SECRET }}" != "" && "${{ secrets.TENANT }}" != "" && "${{ secrets.SERVICE_PRINCIPAL }}" != "" && "${{ secrets.KEYVAULT_NAME }}" != "" ]];
         then
-          echo "::set-env name=AZURE_SET::true"
+          echo "AZURE_SET=true" >> $GITHUB_ENV
         fi
 
         # check that all Docker secrets are set
         if [[ "${{ secrets.DOCKER_PAT }}" != "" && "${{ secrets.DOCKER_REPO }}" != "" && "${{ secrets.DOCKER_USER }}" != "" ]];
         then
-          echo "::set-env name=DOCKER_SET::true"
+          echo "DOCKER_SET=true" >> $GITHUB_ENV
         fi
-        
+
         # check that all ACR secrets are set
         if [[ "${{ secrets.ACR_REG }}" != "" && "${{ secrets.ACR_REPO }}" != "" && "${{ secrets.ACR_IMAGE }}" != "" ]];
         then
-          echo "::set-env name=ACR_SET::true"
+          echo "ACR_SET=true" >> $GITHUB_ENV
         fi
 
     - name: PR Closed
@@ -71,7 +71,7 @@ jobs:
       run: |
 
         # handle PR Closed event by building / pushing main branch
-        
+
         # checkout parent branch (usually "main")
         git config pull.ff only
         git fetch --all
@@ -84,9 +84,9 @@ jobs:
       run: |
 
         # Skip remaining steps - do not build on PR merge - will build on main merge
-        echo "::set-env name=AZURE_SET::false"
-        echo "::set-env name=DOCKER_SET::false"
-        echo "::set-env name=ACR_SET::false"
+        echo "AZURE_SET=false" >> $GITHUB_ENV
+        echo "DOCKER_SET=false" >> $GITHUB_ENV
+        echo "ACR_SET=false" >> $GITHUB_ENV
 
     - name: Validate Azure Access
       if: ${{ env.AZURE_SET == 'true' }}
@@ -126,7 +126,7 @@ jobs:
       run: |
         # run the app
         docker run -d --name hcs -p 4120:4120 --env KEYVAULT_NAME=$KEYVAULT_NAME --env AUTH_TYPE=CLI -v ~/.azure:/root/.azure --env CONFIGURATION="/p:Configuration=Experimental" test
-        
+
         echo "Waiting for web server to start and run initial tests ..."
         sleep 25
 
@@ -174,7 +174,7 @@ jobs:
 
         # Push to the repo
         docker push $DOCKER_REPO
-    
+
     - name: ACR Push
       if: ${{ env.ACR_SET == 'true' && env.AZURE_SET == 'true' }}
       run: |


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [x] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR

The "set-env" syntax for setting environment variables in actions is being deprecated. Update the actions to the new way of setting env vars. Tested actions in a forked repo https://github.com/AAkindele/helium-csharp/actions.

https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable

## Validation

- [ ] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

## Issues Closed or Referenced

- References https://github.com/retaildevcrews/helium/issues/604
